### PR TITLE
fix: update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,14 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
 build:
     image: latest
 
 python:
-    version: 3.6
-
-requirements_file: requirements_dev.txt
+  version: 3.10
+  install:
+    - requirements: requirements_dev.txt


### PR DESCRIPTION
## Description
- Old readthedocs config is causing [failure](https://github.com/edx/repo-health-data/actions/runs/6957714212/job/18931144812#step:9:10990) with latest readthedocs checks when running the repo health job. 
- Attempting a fix by updating the readthedocs yaml config file to the latest version similar to other edx repos.