### PR TITLE
fix: mocking errors for /product-projections/search

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -54,7 +54,7 @@ jobs:
 
     - uses: actions/upload-artifact@master
       with:
-        name: coverage-data
+        name: coverage-data-${{ matrix.python-version }}
         path: .coverage-data/
 
   coverage:
@@ -64,8 +64,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@master
       with:
-        name: coverage-data
+        pattern: coverage-data-*
         path: .
+        merge-multiple: true
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.paths]
-source = ["src", ".tox/*/site-packages"]
+source = ["src", ".tox/**/site-packages"]
 
 [tool.isort]
 line_length = 88

--- a/src/commercetools/testing/cart_discounts.py
+++ b/src/commercetools/testing/cart_discounts.py
@@ -41,6 +41,7 @@ class CartDiscountsModel(BaseModel):
             references=[],
             stacking_mode=draft.stacking_mode or models.StackingMode.STACKING,
             sort_order=draft.sort_order,
+            stores=draft.stores,
             valid_from=draft.valid_from,
             valid_until=draft.valid_until,
             requires_discount_code=draft.requires_discount_code,

--- a/src/commercetools/testing/product_projections.py
+++ b/src/commercetools/testing/product_projections.py
@@ -19,6 +19,7 @@ class ProductProjectionsBackend(ServiceBackend):
     def urls(self):
         return [
             ("^$", "GET", self.query),
+            ("^search", "GET", self.search),
             ("^search", "POST", self.search),
             ("^key=(?P<key>[^/]+)$", "GET", self.get_by_key),
             ("^(?P<id>[^/]+)$", "GET", self.get_by_id),

--- a/src/commercetools/testing/product_projections.py
+++ b/src/commercetools/testing/product_projections.py
@@ -6,7 +6,10 @@ from commercetools.platform.models._schemas.product import (
     ProductProjectionSchema,
     ProductSchema,
 )
-from commercetools.services.product_projections import _ProductProjectionQuerySchema
+from commercetools.services.product_projections import (
+    _ProductProjectionQuerySchema,
+    _ProductProjectionSearchSchema,
+)
 from commercetools.testing import utils
 from commercetools.testing.abstract import ServiceBackend
 from commercetools.testing.utils import create_commercetools_response
@@ -54,7 +57,7 @@ class ProductProjectionsBackend(ServiceBackend):
         return create_commercetools_response(request, text=content)
 
     def search(self, request):
-        params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
+        params = utils.parse_request_params(_ProductProjectionSearchSchema, request)
 
         limit = params.get("limit")
 


### PR DESCRIPTION
## Description

On tests of commercetools-python-sdk SDK calls to [Product Projection Search](https://docs.commercetools.com/api/projects/products-search#product-projection-search), see error:

```
marshmallow.exceptions.ValidationError: {'filter': ['Unknown field.'], 'markmatchingvariants': ['Unknown field.']}
```

This PR corrects the schema and urls used in `commercetools.testing.product_projections`'s `ProductProjectionsBackend.search()` to squash this error.

## Additional Information

See commit messages for explanation of changes.

See details below for full error logs that prompted change.

<details>
<summary>Output of error resolved by a5b5f273d259cfde32e1620c5f32c2b04d2264c8</summary>

Note mocker matches to to `get_by_id()` instead of `search()`:

```
<...>
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/testing/product_projections.py:85: in get_by_id
    params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
<...>
```

Full logs, starting with where `search()` is called:

```
% pytest
<...truncated...>
commerce_coordinator/apps/commercetools/clients.py:240: in get_product_variant_by_course_run
    results = self.base_client.product_projections.search(False, filter=f"variants.sku:\"{cr_id}\"").results
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/services/product_projections.py:294: in search
    return self._client._get(
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/client.py:36: in _get
    response = self._http_client.get(self._base_url + endpoint, params=params)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests/sessions.py:602: in get
    return self.request("GET", url, **kwargs)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests_oauthlib/oauth2_session.py:521: in request
    return super(OAuth2Session, self).request(
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests/sessions.py:589: in request
    resp = self.send(prep, **send_kwargs)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests_mock/mocker.py:185: in _fake_send
    return _original_send(session, request, **kwargs)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests/sessions.py:703: in send
    r = adapter.send(request, **kwargs)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests_mock/adapter.py:248: in send
    resp = matcher(request)
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/testing/abstract.py:174: in _matcher
    response = callback(request, **path_match.groupdict())
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/testing/product_projections.py:85: in get_by_id
    params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/testing/utils.py:32: in parse_request_params
    obj = schema().load(params)
../../.virtualenvs/workarea/lib/python3.8/site-packages/marshmallow/schema.py:722: in load
    return self._do_load(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_ProductProjectionQuerySchema(many=False)>
data = {'filter': 'variants.sku:"course-v1:michiganx+injurypreventionx+1t2021"', 'markmatchingvariants': 'false', 'predicate_var': {}}

    def _do_load(
        self,
        data: (
            typing.Mapping[str, typing.Any]
            | typing.Iterable[typing.Mapping[str, typing.Any]]
        ),
        *,
        many: bool | None = None,
        partial: bool | types.StrSequenceOrSet | None = None,
        unknown: str | None = None,
        postprocess: bool = True,
    ):
        """Deserialize `data`, returning the deserialized result.
        This method is private API.
    
        :param data: The data to deserialize.
        :param many: Whether to deserialize `data` as a collection. If `None`, the
            value for `self.many` is used.
        :param partial: Whether to validate required fields. If its
            value is an iterable, only fields listed in that iterable will be
            ignored will be allowed missing. If `True`, all fields will be allowed missing.
            If `None`, the value for `self.partial` is used.
        :param unknown: Whether to exclude, include, or raise an error for unknown
            fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
            If `None`, the value for `self.unknown` is used.
        :param postprocess: Whether to run post_load methods..
        :return: Deserialized data
        """
        error_store = ErrorStore()
        errors = {}  # type: dict[str, list[str]]
        many = self.many if many is None else bool(many)
        unknown = (
            self.unknown
            if unknown is None
            else validate_unknown_parameter_value(unknown)
        )
        if partial is None:
            partial = self.partial
        # Run preprocessors
        if self._has_processors(PRE_LOAD):
            try:
                processed_data = self._invoke_load_processors(
                    PRE_LOAD, data, many=many, original_data=data, partial=partial
                )
            except ValidationError as err:
                errors = err.normalized_messages()
                result = None  # type: list | dict | None
        else:
            processed_data = data
        if not errors:
            # Deserialize data
            result = self._deserialize(
                processed_data,
                error_store=error_store,
                many=many,
                partial=partial,
                unknown=unknown,
            )
            # Run field-level validation
            self._invoke_field_validators(
                error_store=error_store, data=result, many=many
            )
            # Run schema-level validation
            if self._has_processors(VALIDATES_SCHEMA):
                field_errors = bool(error_store.errors)
                self._invoke_schema_validators(
                    error_store=error_store,
                    pass_many=True,
                    data=result,
                    original_data=data,
                    many=many,
                    partial=partial,
                    field_errors=field_errors,
                )
                self._invoke_schema_validators(
                    error_store=error_store,
                    pass_many=False,
                    data=result,
                    original_data=data,
                    many=many,
                    partial=partial,
                    field_errors=field_errors,
                )
            errors = error_store.errors
            # Run post processors
            if not errors and postprocess and self._has_processors(POST_LOAD):
                try:
                    result = self._invoke_load_processors(
                        POST_LOAD,
                        result,
                        many=many,
                        original_data=data,
                        partial=partial,
                    )
                except ValidationError as err:
                    errors = err.normalized_messages()
        if errors:
            exc = ValidationError(errors, data=data, valid_data=result)
            self.handle_error(exc, data, many=many, partial=partial)
>           raise exc
E           marshmallow.exceptions.ValidationError: {'filter': ['Unknown field.'], 'markmatchingvariants': ['Unknown field.']}

../../.virtualenvs/workarea/lib/python3.8/site-packages/marshmallow/schema.py:909: ValidationError

```
</details>

<details>
<summary>Output of error resolved by 59c762312d71732d5b8de5e67767c6d056ab0e49</summary>

Note now call is to `search()`:

```
<...>
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/testing/product_projections.py:57: in search
    params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
<...>
```

but `_ProductProjectionQuerySchema` is used instead of `_ProductProjectionSearchSchema`:

```
<...>
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/testing/product_projections.py:57: in search
    params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
<...>
```

Full logs:

```
% pytest
<...truncated...>
commerce_coordinator/apps/commercetools/clients.py:240: in get_product_variant_by_course_run
    results = self.base_client.product_projections.search(False, filter=f"variants.sku:\"{cr_id}\"").results
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/services/product_projections.py:294: in search
    return self._client._get(
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/client.py:36: in _get
    response = self._http_client.get(self._base_url + endpoint, params=params)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests/sessions.py:602: in get
    return self.request("GET", url, **kwargs)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests_oauthlib/oauth2_session.py:521: in request
    return super(OAuth2Session, self).request(
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests/sessions.py:589: in request
    resp = self.send(prep, **send_kwargs)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests_mock/mocker.py:185: in _fake_send
    return _original_send(session, request, **kwargs)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests/sessions.py:703: in send
    r = adapter.send(request, **kwargs)
../../.virtualenvs/workarea/lib/python3.8/site-packages/requests_mock/adapter.py:248: in send
    resp = matcher(request)
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/testing/abstract.py:174: in _matcher
    response = callback(request, **path_match.groupdict())
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/testing/product_projections.py:57: in search
    params = utils.parse_request_params(_ProductProjectionQuerySchema, request)
../../.virtualenvs/workarea/lib/python3.8/site-packages/commercetools/testing/utils.py:32: in parse_request_params
    obj = schema().load(params)
../../.virtualenvs/workarea/lib/python3.8/site-packages/marshmallow/schema.py:722: in load
    return self._do_load(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_ProductProjectionQuerySchema(many=False)>
data = {'filter': 'variants.sku:"course-v1:michiganx+injurypreventionx+1t2021"', 'markmatchingvariants': 'false', 'predicate_var': {}}

    def _do_load(
        self,
        data: (
            typing.Mapping[str, typing.Any]
            | typing.Iterable[typing.Mapping[str, typing.Any]]
        ),
        *,
        many: bool | None = None,
        partial: bool | types.StrSequenceOrSet | None = None,
        unknown: str | None = None,
        postprocess: bool = True,
    ):
        """Deserialize `data`, returning the deserialized result.
        This method is private API.
    
        :param data: The data to deserialize.
        :param many: Whether to deserialize `data` as a collection. If `None`, the
            value for `self.many` is used.
        :param partial: Whether to validate required fields. If its
            value is an iterable, only fields listed in that iterable will be
            ignored will be allowed missing. If `True`, all fields will be allowed missing.
            If `None`, the value for `self.partial` is used.
        :param unknown: Whether to exclude, include, or raise an error for unknown
            fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
            If `None`, the value for `self.unknown` is used.
        :param postprocess: Whether to run post_load methods..
        :return: Deserialized data
        """
        error_store = ErrorStore()
        errors = {}  # type: dict[str, list[str]]
        many = self.many if many is None else bool(many)
        unknown = (
            self.unknown
            if unknown is None
            else validate_unknown_parameter_value(unknown)
        )
        if partial is None:
            partial = self.partial
        # Run preprocessors
        if self._has_processors(PRE_LOAD):
            try:
                processed_data = self._invoke_load_processors(
                    PRE_LOAD, data, many=many, original_data=data, partial=partial
                )
            except ValidationError as err:
                errors = err.normalized_messages()
                result = None  # type: list | dict | None
        else:
            processed_data = data
        if not errors:
            # Deserialize data
            result = self._deserialize(
                processed_data,
                error_store=error_store,
                many=many,
                partial=partial,
                unknown=unknown,
            )
            # Run field-level validation
            self._invoke_field_validators(
                error_store=error_store, data=result, many=many
            )
            # Run schema-level validation
            if self._has_processors(VALIDATES_SCHEMA):
                field_errors = bool(error_store.errors)
                self._invoke_schema_validators(
                    error_store=error_store,
                    pass_many=True,
                    data=result,
                    original_data=data,
                    many=many,
                    partial=partial,
                    field_errors=field_errors,
                )
                self._invoke_schema_validators(
                    error_store=error_store,
                    pass_many=False,
                    data=result,
                    original_data=data,
                    many=many,
                    partial=partial,
                    field_errors=field_errors,
                )
            errors = error_store.errors
            # Run post processors
            if not errors and postprocess and self._has_processors(POST_LOAD):
                try:
                    result = self._invoke_load_processors(
                        POST_LOAD,
                        result,
                        many=many,
                        original_data=data,
                        partial=partial,
                    )
                except ValidationError as err:
                    errors = err.normalized_messages()
        if errors:
            exc = ValidationError(errors, data=data, valid_data=result)
            self.handle_error(exc, data, many=many, partial=partial)
>           raise exc
E           marshmallow.exceptions.ValidationError: {'filter': ['Unknown field.'], 'markmatchingvariants': ['Unknown field.']}

../../.virtualenvs/workarea/lib/python3.8/site-packages/marshmallow/schema.py:909: ValidationError

```
</details>