### PR TITLE
feat: add pypi-publish.yml

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,30 @@
+name: Publish package to PyPI
+
+on:
+  push:
+    tags: 
+      - '*'
+
+jobs:
+  push:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install pip
+        run: pip install -r requirements/pip.txt
+
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
## Description

Add GitHub workflow to publish this to PyPI.

## Additional Information

### Rationale

What pip releases do is:

- Allow us to change the sdk's master without bumping the code in stage
  - or, if we pin to a sha, remove a step someone might forget to manually bump the sha
- Allow us to re-use the requirements upgrade scripts to keep our code up-to-date
- Keeps us consistent with the rest of the dependencies in coordinator, eliminating "one more way" we do things